### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/iyaki/web-archiver/security/code-scanning/3](https://github.com/iyaki/web-archiver/security/code-scanning/3)

In general, the fix is to explicitly define a `permissions:` block to restrict the `GITHUB_TOKEN` to the minimal access required. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and run local Go commands; they do not need to write anything back to GitHub. Therefore `contents: read` is sufficient.

The best minimal change is to add a workflow-level `permissions:` block right after the `name: Build` (or anywhere at the top level alongside `on:` and `jobs:`). This will apply to all jobs that do not override permissions, including `build`. No other code, steps, or actions need to change. Specifically, in `.github/workflows/build.yml`, insert:

```yaml
permissions:
  contents: read
```

between the existing `name: Build` and `on:` keys. This does not require any imports or additional methods, as it is pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
